### PR TITLE
fixed vulnerabilities CVE-2022-30123

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.1.2)
+    rack (2.2.4)
     rack-livereload (0.3.16)
       rack
     rb-fsevent (0.9.8)


### PR DESCRIPTION
## Descriptions
There is a possible shell escape sequence injection vulnerability in the Lint
and CommonLogger components of Rack. This vulnerability has been assigned the
CVE identifier https://github.com/advisories/GHSA-wq4h-7r42-5hrr.

## Impact
Carefully crafted requests can cause shell escape sequences to be written to
the terminal via Rack's Lint middleware and CommonLogger middleware. These
escape sequences can be leveraged to possibly execute commands in the victim's
terminal.

Impacted applications will have either of these middleware installed, and
vulnerable apps may have something like this:
```
use Rack::Lint
```
Or
```
use Rack::CommonLogger
```
All users running an affected release should either upgrade or use one of the
workarounds immediately.

**CVE-2022-30123**
GHSA-wq4h-7r42-5hrr
